### PR TITLE
Rename EvosMovesPointerTable to EvosAttacksPointers to sync with pokecrystal #315

### DIFF
--- a/constants/pokemon_constants.asm
+++ b/constants/pokemon_constants.asm
@@ -1,7 +1,7 @@
 ; pokemon ids
 ; indexes for:
 ; - MonsterNames (see data/pokemon/names.asm)
-; - EvosMovesPointerTable (see data/pokemon/evos_moves.asm)
+; - EvosAttacksPointers (see data/pokemon/evos_moves.asm)
 ; - CryData (see data/pokemon/cries.asm)
 ; - PokedexOrder (see data/pokemon/dex_order.asm)
 ; - PokedexEntryPointers (see data/pokemon/dex_entries.asm)

--- a/data/pokemon/evos_moves.asm
+++ b/data/pokemon/evos_moves.asm
@@ -1,8 +1,8 @@
 ; See constants/pokemon_data_constants.asm
 ; The max number of evolutions per monster is MAX_EVOLUTIONS
 
-EvosMovesPointerTable:
-	table_width 2, EvosMovesPointerTable
+EvosAttacksPointers:
+	table_width 2, EvosAttacksPointers
 	dw RhydonEvosMoves
 	dw KangaskhanEvosMoves
 	dw NidoranMEvosMoves

--- a/engine/menus/party_menu.asm
+++ b/engine/menus/party_menu.asm
@@ -113,7 +113,7 @@ RedrawPartyMenu_::
 	db "NOT ABLE@"
 .evolutionStoneMenu
 	push hl
-	ld hl, EvosMovesPointerTable
+	ld hl, EvosAttacksPointers
 	ld b, 0
 	ld a, [wLoadedMonSpecies]
 	dec a
@@ -122,7 +122,7 @@ RedrawPartyMenu_::
 	ld c, a
 	add hl, bc
 	ld de, wEvosMoves
-	ld a, BANK(EvosMovesPointerTable)
+	ld a, BANK(EvosAttacksPointers)
 	ld bc, 2
 	call FarCopyData
 	ld hl, wEvosMoves
@@ -130,7 +130,7 @@ RedrawPartyMenu_::
 	ld h, [hl]
 	ld l, a
 	ld de, wEvosMoves
-	ld a, BANK(EvosMovesPointerTable)
+	ld a, BANK(EvosAttacksPointers)
 	ld bc, wEvosMovesEnd - wEvosMoves
 	call FarCopyData
 	ld hl, wEvosMoves

--- a/engine/pokemon/evos_moves.asm
+++ b/engine/pokemon/evos_moves.asm
@@ -44,7 +44,7 @@ Evolution_PartyMonLoop: ; loop over party mons
 	ld a, [wEvoOldSpecies]
 	dec a
 	ld b, 0
-	ld hl, EvosMovesPointerTable
+	ld hl, EvosAttacksPointers
 	add a
 	rl b
 	ld c, a
@@ -318,12 +318,12 @@ Evolution_ReloadTilesetTilePatterns:
 	jp ReloadTilesetTilePatterns
 
 LearnMoveFromLevelUp:
-	ld hl, EvosMovesPointerTable
+	ld hl, EvosAttacksPointers
 	ld a, [wd11e] ; species
 	ld [wcf91], a
 	dec a
 	ld bc, 0
-	ld hl, EvosMovesPointerTable
+	ld hl, EvosAttacksPointers
 	add a
 	rl b
 	ld c, a
@@ -382,7 +382,7 @@ WriteMonMoves:
 	push hl
 	push de
 	push bc
-	ld hl, EvosMovesPointerTable
+	ld hl, EvosAttacksPointers
 	ld b, 0
 	ld a, [wcf91]  ; cur mon ID
 	dec a


### PR DESCRIPTION
This PR have for goal to sync the name of pointer for evo attacks like pokecrystal.

Related to the issue #315